### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt.example
+++ b/CMakeLists.txt.example
@@ -4,7 +4,7 @@ project (example CXX)
 set(sources main.cpp)
 
 # include_directories(
-# 	~/Kvasir/Lib
+# 	/Kvasir/Lib
 # )
 
 # Where the toolchain is located on your pc.

--- a/CMakeLists.txt.example
+++ b/CMakeLists.txt.example
@@ -3,19 +3,18 @@ project (example CXX)
 
 set(sources main.cpp)
 
-include_directories(        
-	/home/carlos/gits/Kvasir/Lib
-)
+# include_directories(
+# 	~/Kvasir/Lib
+# )
 
+# Where the toolchain is located on your pc.
+set(toolchain ~/kvasir_toolchain) # Your path to kvasir_toolchain
 
-#Where the toolchain is located on your pc.
-set(toolchain /home/carlos/gits/kvasir_toolchain)
+# The compiler that is used:
+include(${toolchain}/compilers/arm-none-eabi.cmake)
 
-#The compiler that is used:
-include(compilers/arm-none-eabi.cmake)
+# The target chip that is compiled for:
+include(${toolchain}/targets/arm32/cm4/nordic/nrf/nrf52/nrf52.cmake)
 
-#The target chip that is compiled for:
-include(targets/arm32/cm4/nordic/nrf/nrf52/nrf52.cmake)
-
-#The flashscript used to flash the script:
-include(targets/arm32/cm4/nordic/nrf/nrf52/flashscripts/nrfjprog.cmake)
+# The flashscript used to flash the script:
+include(${toolchain}/targets/arm32/cm4/nordic/nrf/nrf52/flashscripts/nrfjprog.cmake)

--- a/compilers/arm-none-eabi.cmake
+++ b/compilers/arm-none-eabi.cmake
@@ -2,7 +2,8 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 set(OBJCOPY arm-none-eabi-objcopy)
 
+set(CMAKE_C_COMPILER_WORKS 1)
+
 set(CMAKE_ASM_COMPILER arm-none-eabi-gcc)
 set(CMAKE_C_COMPILER arm-none-eabi-gcc)
 set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
-


### PR DESCRIPTION
This PR fixes an issue where CMake says the compiler fails because it tries compiling and running a program for an architecture we are not on.
It also fixes the use of relative paths in CMakeLists.txt.example which causes failing when you copy the file