### PR TITLE
Added options to set location of bossac

### DIFF
--- a/CMakeLists.txt.example
+++ b/CMakeLists.txt.example
@@ -18,3 +18,6 @@ include(${toolchain}/targets/arm32/cm4/nordic/nrf/nrf52/nrf52.cmake)
 
 # The flashscript used to flash the binary (optional):
 include(${toolchain}/targets/arm32/cm4/nordic/nrf/nrf52/flashscripts/nrfjprog.cmake)
+
+# Location of the flash tool if it's not in your path
+#set(flash_program_path ~/bossac)

--- a/CMakeLists.txt.example
+++ b/CMakeLists.txt.example
@@ -10,6 +10,9 @@ set(sources main.cpp)
 # Where the toolchain is located on your pc.
 set(toolchain ~/kvasir_toolchain) # Your path to kvasir_toolchain
 
+# Location of the flash tool if it's not in your path
+#set(flash_program_path ~/bossac) # Your path to the flash tool
+
 # The compiler that is used:
 include(${toolchain}/compilers/arm-none-eabi.cmake)
 
@@ -19,5 +22,3 @@ include(${toolchain}/targets/arm32/cm4/nordic/nrf/nrf52/nrf52.cmake)
 # The flashscript used to flash the binary (optional):
 include(${toolchain}/targets/arm32/cm4/nordic/nrf/nrf52/flashscripts/nrfjprog.cmake)
 
-# Location of the flash tool if it's not in your path
-#set(flash_program_path ~/bossac)

--- a/targets/arm32/cm3/atmel/sam3x/sam3x8e/flashscripts/arduino_due.cmake
+++ b/targets/arm32/cm3/atmel/sam3x/sam3x8e/flashscripts/arduino_due.cmake
@@ -1,15 +1,14 @@
-find_program(bossac "bossac")
+find_program(bossac "bossac" HINTS ${flash_program_path})
 if(NOT bossac)
-	message([warning] "bossac not found. This program is nessecery to flash the Arduino Due chip. Please install this program and add it to your path before continuing.")
+	message([warning] "bossac not found.This program is nessecery to flash the Arduino Due chip. Please install this program and add it to your path or set flash_program_path in your CMakeLists.txt before continuing.")
 endif()
-
 set(DEVICE_LOCATION
         "ttyACM0"
 )
 
 if(bossac)
         add_custom_target(flash DEPENDS ${PROJECT_NAME}.bin
-                COMMAND bossac -p ${DEVICE_LOCATION} -U false -e -w -v -b ${PROJECT_NAME}.bin -R
+                COMMAND ${bossac} -p ${DEVICE_LOCATION} -U false -e -w -v -b ${PROJECT_NAME}.bin -R
                 # ^ erease -> write -> verify -> boot -> reset
         )
 endif()


### PR DESCRIPTION
I ran into this issue cause I didn't want to add bossac to my path.
Fixed it by adding a new variable to the flash tool cmakelist.

I don't know how the `nrfjprog` of the nordic chip works so i didn't add it there. It uses `find_program` to find it so it could benefit from a addition of a hint as well.